### PR TITLE
fix: Correct tool configuration in Live API setup

### DIFF
--- a/server.py
+++ b/server.py
@@ -101,27 +101,27 @@ def get_live_api_config(
     # ),
     voice_name="Despina",
     system_instruction=SYSTEM_INSTRUCTION,
-    tools=[],
+    tools=TOOLS,
     # proactivity=ProactivityConfig(proactive_audio=True),   
 ):
     return LiveConnectConfig(
-    response_modalities=response_modalities,
-    output_audio_transcription={},
-    input_audio_transcription={},
-    # session_resumption=types.SessionResumptionConfig(
-    # The handle of the session to resume is passed here,
-    # or else None to start a new session.
-    # handle="93f6ae1d-2420-40e9-828c-776cf553b7a6"
-    # ),
-    speech_config=SpeechConfig(
-        voice_config=VoiceConfig(
-            prebuilt_voice_config=PrebuiltVoiceConfig(voice_name=voice_name)
-        )
-    ),
-    system_instruction=system_instruction,
-    tools=TOOLS,
-    # proactivity=ProactivityConfig(proactive_audio=True),
-)
+        response_modalities=response_modalities,
+        output_audio_transcription={},
+        input_audio_transcription={},
+        # session_resumption=types.SessionResumptionConfig(
+        # The handle of the session to resume is passed here,
+        # or else None to start a new session.
+        # handle="93f6ae1d-2420-40e9-828c-776cf553b7a6"
+        # ),
+        speech_config=SpeechConfig(
+            voice_config=VoiceConfig(
+                prebuilt_voice_config=PrebuiltVoiceConfig(voice_name=voice_name)
+            )
+        ),
+        system_instruction=system_instruction,
+        tools=tools,
+        # proactivity=ProactivityConfig(proactive_audio=True),
+    )
 
 CONNECTED_CLIENTS = set()
 class ResponseType:


### PR DESCRIPTION
## 📝작업 내용

- get_live_api_config 함수에서 tools=[] (빈 배열)로 받고 있음
- 하지만 LiveConnectConfig에서는 tools=TOOLS를 사용

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트 혹은 테스트 코드를 작성했습니다.